### PR TITLE
Enable dash with both shift keys

### DIFF
--- a/client/src/game/InputManager.ts
+++ b/client/src/game/InputManager.ts
@@ -10,7 +10,21 @@ export class InputManager {
     
     // Prevent default behavior for game keys
     window.addEventListener('keydown', (e) => {
-      const gameKeys = ['Space', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyJ', 'KeyK', 'ShiftLeft'];
+      const gameKeys = [
+        'Space',
+        'ArrowUp',
+        'ArrowDown',
+        'ArrowLeft',
+        'ArrowRight',
+        'KeyW',
+        'KeyA',
+        'KeyS',
+        'KeyD',
+        'KeyJ',
+        'KeyK',
+        'ShiftLeft',
+        'ShiftRight',
+      ];
       if (gameKeys.includes(e.code)) {
         e.preventDefault();
       }

--- a/client/src/game/Player.ts
+++ b/client/src/game/Player.ts
@@ -106,7 +106,10 @@ export class Player {
     }
     
     // Dash (only horizontal for side-scrolling)
-    if (input.isKeyJustPressed('ShiftLeft') && this.dashCooldown <= 0) {
+    if (
+      (input.isKeyJustPressed('ShiftLeft') || input.isKeyJustPressed('ShiftRight')) &&
+      this.dashCooldown <= 0
+    ) {
       this.dashDuration = this.maxDashDuration;
       this.dashCooldown = this.maxDashCooldown;
       this.currentAnimation = 'dash';


### PR DESCRIPTION
## Summary
- allow dash with either Shift key
- prevent default browser action on `ShiftRight`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c938f5ac08325ab73b46533689104