### PR TITLE
Fix input processing timing and cleanup listeners

### DIFF
--- a/client/src/game/GameEngine.ts
+++ b/client/src/game/GameEngine.ts
@@ -124,9 +124,6 @@ export class GameEngine {
   }
 
   private updateGame(deltaTime: number) {
-    // Update input
-    this.inputManager.update();
-
     // Update player
     this.player.update(deltaTime, this.inputManager);
 
@@ -157,6 +154,9 @@ export class GameEngine {
 
     // Notify state updates
     this.notifyStateUpdate();
+
+    // Update input after game logic
+    this.inputManager.update();
   }
 
   private render() {

--- a/client/src/game/InputManager.ts
+++ b/client/src/game/InputManager.ts
@@ -3,10 +3,14 @@ export class InputManager {
   private justPressedKeys: Set<string> = new Set();
   private justReleasedKeys: Set<string> = new Set();
   private virtualInputs: Set<string> = new Set();
+  private boundHandleKeyDown?: (e: KeyboardEvent) => void;
+  private boundHandleKeyUp?: (e: KeyboardEvent) => void;
 
   initialize() {
-    window.addEventListener('keydown', this.handleKeyDown.bind(this));
-    window.addEventListener('keyup', this.handleKeyUp.bind(this));
+    this.boundHandleKeyDown = this.handleKeyDown.bind(this);
+    this.boundHandleKeyUp = this.handleKeyUp.bind(this);
+    window.addEventListener('keydown', this.boundHandleKeyDown);
+    window.addEventListener('keyup', this.boundHandleKeyUp);
     
     // Prevent default behavior for game keys
     window.addEventListener('keydown', (e) => {
@@ -77,7 +81,11 @@ export class InputManager {
   }
 
   destroy() {
-    window.removeEventListener('keydown', this.handleKeyDown.bind(this));
-    window.removeEventListener('keyup', this.handleKeyUp.bind(this));
+    if (this.boundHandleKeyDown) {
+      window.removeEventListener('keydown', this.boundHandleKeyDown);
+    }
+    if (this.boundHandleKeyUp) {
+      window.removeEventListener('keyup', this.boundHandleKeyUp);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- update input after applying game logic so justPressed works
- keep references to input handlers for proper removal

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684c91b35a048325a23a4e00fc3aeb7b