### PR TITLE
Add vitest with storage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.5",
@@ -119,7 +120,8 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^1.5.1"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/storage.test.ts
+++ b/server/storage.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { MemStorage } from './storage'
+
+describe('MemStorage', () => {
+  let storage: MemStorage
+
+  beforeEach(() => {
+    storage = new MemStorage()
+  })
+
+  it('increments ID when creating users', async () => {
+    const user1 = await storage.createUser({ username: 'alice', password: 's' })
+    expect(user1.id).toBe(1)
+    const user2 = await storage.createUser({ username: 'bob', password: 's' })
+    expect(user2.id).toBe(2)
+  })
+
+  it('retrieves users by ID and username', async () => {
+    const created = await storage.createUser({ username: 'carol', password: 's' })
+    const byId = await storage.getUser(created.id)
+    expect(byId).toEqual(created)
+    const byUsername = await storage.getUserByUsername('carol')
+    expect(byUsername).toEqual(created)
+  })
+})


### PR DESCRIPTION
## Summary
- add `vitest` dev dependency and npm test script
- test `MemStorage` user CRUD logic

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8effcef48325a6a88a8ab12b27b6