### PR TITLE
Fix enemy physics updates

### DIFF
--- a/client/src/game/Enemy.ts
+++ b/client/src/game/Enemy.ts
@@ -1,4 +1,4 @@
-import { Vector2, EnemyAI, HitBox } from "./types";
+import { Vector2, EnemyAI, HitBox, Rectangle } from "./types";
 
 export class Enemy {
   private id: string;
@@ -355,13 +355,17 @@ export class Enemy {
     this.state = 'chasing';
   }
 
-  getBounds() {
+  getBounds(): Rectangle {
     return {
       x: this.position.x - this.size.x / 2,
       y: this.position.y - this.size.y / 2,
       width: this.size.x,
       height: this.size.y
     };
+  }
+
+  getSize(): Vector2 {
+    return { ...this.size };
   }
 
   private checkForObstacle(direction: number, distance: number, platforms?: any[]): boolean {
@@ -394,8 +398,8 @@ export class Enemy {
 
   // Getters
   getId(): string { return this.id; }
-  getPosition(): Vector2 { return { ...this.position }; }
-  getVelocity(): Vector2 { return { ...this.velocity }; }
+  getPosition(): Vector2 { return this.position; }
+  getVelocity(): Vector2 { return this.velocity; }
   getHealth(): number { return this.health; }
   getMaxHealth(): number { return this.maxHealth; }
   getType(): string { return this.type; }

--- a/client/src/game/Physics.ts
+++ b/client/src/game/Physics.ts
@@ -17,7 +17,7 @@ export class Physics {
   }
 
   private updatePlayerPhysics(player: Player, level: Level) {
-    const playerBounds = player.getBounds();
+    const playerBounds: Rectangle = player.getBounds();
     const platforms = level.getPlatforms();
     const playerPos = player.getPosition();
     const playerVel = player.getVelocity();
@@ -60,7 +60,9 @@ export class Physics {
   }
 
   private updateEnemyPhysics(enemy: Enemy, level: Level) {
-    const enemyBounds = enemy.getBounds();
+    const enemyBounds: Rectangle = enemy.getBounds();
+    const enemyPos = enemy.getPosition();
+    const enemyVel = enemy.getVelocity();
     const platforms = level.getPlatforms();
     
     // Check ground collision for non-flying enemies
@@ -68,10 +70,10 @@ export class Physics {
       platforms.forEach(platform => {
         if (this.checkCollision(enemyBounds, platform)) {
           const overlapY = (enemyBounds.y + enemyBounds.height) - platform.y;
-          
-          if (overlapY > 0 && overlapY < 20 && enemy.getVelocity().y >= 0) {
-            enemy.getPosition().y = platform.y - enemyBounds.height / 2;
-            enemy.getVelocity().y = 0;
+
+          if (overlapY > 0 && overlapY < 20 && enemyVel.y >= 0) {
+            enemyPos.y = platform.y - enemyBounds.height / 2;
+            enemyVel.y = 0;
           }
         }
       });
@@ -79,14 +81,13 @@ export class Physics {
     
     // World boundaries
     const worldBounds = level.getWorldBounds();
-    const pos = enemy.getPosition();
     
-    if (pos.x < worldBounds.left || pos.x > worldBounds.right) {
+    if (enemyPos.x < worldBounds.left || enemyPos.x > worldBounds.right) {
       // Turn around at world boundaries
-      enemy.getVelocity().x *= -1;
+      enemyVel.x *= -1;
     }
-    
-    if (pos.y > worldBounds.bottom + 100) {
+
+    if (enemyPos.y > worldBounds.bottom + 100) {
       // Remove enemy if it falls too far
       enemy.takeDamage(1000, { x: 0, y: 0 });
     }

--- a/client/src/game/Player.ts
+++ b/client/src/game/Player.ts
@@ -1,4 +1,4 @@
-import { Vector2, HitBox, Animation } from "./types";
+import { Vector2, HitBox, Animation, Rectangle } from "./types";
 import { InputManager } from "./InputManager";
 
 export class Player {
@@ -238,13 +238,17 @@ export class Player {
     this._isGrounded = grounded;
   }
 
-  getBounds() {
+  getBounds(): Rectangle {
     return {
       x: this.position.x - this.size.x / 2,
       y: this.position.y - this.size.y / 2,
       width: this.size.x,
       height: this.size.y
     };
+  }
+
+  getSize(): Vector2 {
+    return { ...this.size };
   }
 
   // Getters


### PR DESCRIPTION
## Summary
- return enemy position and velocity references instead of copies
- keep local references for enemy physics calculations
- add explicit Rectangle return types and type hints

## Testing
- `npm run check` *(fails: cannot use namespace 'Express' as a type)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687816366b8883258a571b40aac4c98d